### PR TITLE
Update sage.php - no need to delete assets

### DIFF
--- a/recipe/sage.php
+++ b/recipe/sage.php
@@ -22,7 +22,6 @@ task( 'sage:compile', function () {
 
 desc( 'Updates remote assets with local assets' );
 task( 'sage:upload_assets', function () {
-    run( 'rm -rf {{current_path}}/{{theme_path}}/dist' );
     upload( '{{local_root}}/{{theme_path}}/dist', '{{release_path}}/{{theme_path}}' );
 } );
 


### PR DESCRIPTION
I can't see why we need to delete assets on the remote host before deploying our assets?