### PR TITLE
Replaced getenv to $_ENV['WP_HOME']

### DIFF
--- a/lib/functions.php
+++ b/lib/functions.php
@@ -13,7 +13,7 @@ if (!isset($getLocalEnv)) {
     $getLocalEnv = function () {
         $localEnv = Dotenv\Dotenv::createMutable(get('local_root'), '.env');
         $localEnv->load();
-        $localUrl = getenv('WP_HOME');
+        $localUrl = $_ENV['WP_HOME'];
 
         if (!$localUrl) {
             writeln("<error>WP_HOME variable not found in local .env file</error>");
@@ -38,7 +38,7 @@ if (!isset($getRemoteEnv)) {
         download(get('current_path') . '/.env', $tmpEnvFile);
         $remoteEnv = Dotenv\Dotenv::createMutable(get('local_root'), '.env-remote');
         $remoteEnv->load();
-        $remoteUrl = getenv('WP_HOME');
+        $remoteUrl = $_ENV['WP_HOME'];
         // Cleanup tempfile
         runLocally("rm {$tmpEnvFile}");
 


### PR DESCRIPTION
During try pull or push database I recieved error:
`WP_HOME variable not found in remote .env file`
I found simple solution in this [Issue #349](https://github.com/vlucas/phpdotenv/issues/349) and this repo [phpdotenv](https://github.com/vlucas/phpdotenv#putenv-and-getenv)