### PR TITLE
Rsync flag -L for downloading remote-env via symlink

### DIFF
--- a/lib/functions.php
+++ b/lib/functions.php
@@ -35,7 +35,9 @@ if (!isset($getLocalEnv)) {
 if (!isset($getRemoteEnv)) {
     $getRemoteEnv = function () {
         $tmpEnvFile = get('local_root') . '/.env-remote';
-        download(get('current_path') . '/.env', $tmpEnvFile);
+        download(get('current_path') . '/.env', $tmpEnvFile, [
+            'flags' => '-L'
+        ]);
         $remoteEnv = Dotenv\Dotenv::createMutable(get('local_root'), '.env-remote');
         $remoteEnv->load();
         $remoteUrl = $_ENV['WP_HOME'];


### PR DESCRIPTION
In case when the remote `.env` is stored as symlink 
```php
add('shared_files', [
    '.env',
    'web/.htaccess',
    'web/robots.txt',
]);
```
or
```yaml
config:
  shared_files:
    - .env
    - web/.htaccess
    - web/robots.txt
```


using the Deployer directive `shared_files` we got the error:
```bash
[host]  Dotenv\Exception\InvalidPathException  in FileStore.php on line 68:
[host]
[host]   Unable to read any of the environment file(s) at [/path/to/local/.env-remote].
[host]
**ERROR: Task push:db failed!**
```

It happens because Rsync can't download `.env` when it's stored as a symlink
```bash
ll -a
total 372
drwxrwxr-x  5 user user   4096 May 15 09:00 .
drwxrwxr-x  3 user user   4096 May 15 09:00 ..
lrwxrwxrwx  1 user user     17 May 15 09:00 **.env -> ../../shared/.env**
-rw-rw-r--  1 user user    822 May 14 19:55 .env.example
```

The flag `-L` transform symlink into referent file
https://linux.die.net/man/1/rsync