### PR TITLE
Replaced Dotenv method from `load` to `parse`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "florianmoser/bedrock-deployer",
     "description": "Deployer recipes for Roots Bedrock",
     "require": {
-        "deployer/deployer": ">=6.0",
+        "deployer/deployer": ">=7.0",
         "vlucas/phpdotenv": "^5.3"
     },
     "license": "MIT",

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -11,9 +11,10 @@ use Dotenv;
  */
 if (!isset($getLocalEnv)) {
     $getLocalEnv = function () {
-        $localEnv = Dotenv\Dotenv::createMutable(get('local_root'), '.env');
-        $localEnv->load();
-        $localUrl = $_ENV['WP_HOME'];
+        $envFile = realpath(get('local_root')) . '/.env';
+        $content = file_get_contents($envFile);
+        $envData = Dotenv\Dotenv::parse($content);
+        $localUrl = $envData['WP_HOME'];
 
         if (!$localUrl) {
             writeln("<error>WP_HOME variable not found in local .env file</error>");
@@ -34,13 +35,15 @@ if (!isset($getLocalEnv)) {
  */
 if (!isset($getRemoteEnv)) {
     $getRemoteEnv = function () {
-        $tmpEnvFile = get('local_root') . '/.env-remote';
+        $tmpEnvFile = realpath(get('local_root')) . '/.env-remote';
         download(get('current_path') . '/.env', $tmpEnvFile, [
             'flags' => '-L'
         ]);
-        $remoteEnv = Dotenv\Dotenv::createMutable(get('local_root'), '.env-remote');
-        $remoteEnv->load();
-        $remoteUrl = $_ENV['WP_HOME'];
+
+        $content = file_get_contents($tmpEnvFile);
+        $envData = Dotenv\Dotenv::parse($content);
+        $remoteUrl = $envData['WP_HOME'];
+
         // Cleanup tempfile
         runLocally("rm {$tmpEnvFile}");
 


### PR DESCRIPTION
After installing the last version of Bedrock, especially after the next commit https://github.com/roots/bedrock/commit/3eccb5b7ec4c96f9669db59a078b60ce8e7c2c3a I had the error 
`Error: Error establishing a database connection.` when I tried to run `pull:db`.
After testing I identified that this error occurs after `load` method in `lib/functions.php`.